### PR TITLE
Register log levels as method methods.

### DIFF
--- a/electronifie-llog-bunyan.js
+++ b/electronifie-llog-bunyan.js
@@ -1,18 +1,30 @@
-log = Npm.require('llog');
-
-this.Logger = log;
-
 var levels = [ "info", "warn", "error", "debug", "fatal", "trace" ];
 
-// Add meteor methods
-levels.forEach(function(level) {
-  var method = {};
-  var methodName = "log." + level;
+if (Meteor.isServer) {
+  log = Npm.require('llog');
 
-  method[methodName] = function(msg) {
-    log[level]({userId:this.userId, clientAddress: this.connection.clientAddress}, msg);
-  }
+  this.Logger = log;
 
-  Meteor.methods(method)
-}.bind(this));
+  // Add meteor methods
+  levels.forEach(function(level) {
+    var method = {};
+    var methodName = "log." + level;
+
+    method[methodName] = function(msg) {
+      log[level]({userId:this.userId, clientAddress: this.connection.clientAddress}, msg);
+    }
+
+    Meteor.methods(method)
+  }.bind(this));
+} else {
+  this.Logger = {};
+  levels.forEach(function(level) {
+    var methodName = "log." + level;
+
+    this.Logger[level] = function(msg) {
+      Meteor.call(methodName, msg);
+    };
+
+  }.bind(this));
+}
 

--- a/electronifie-llog-bunyan.js
+++ b/electronifie-llog-bunyan.js
@@ -1,4 +1,18 @@
 log = Npm.require('llog');
 
-// Make sure to remove the "logging" package before doing this (Package.logging.Log)
 this.Logger = log;
+
+var levels = [ "info", "warn", "error", "debug", "fatal", "trace" ];
+
+// Add meteor methods
+levels.forEach(function(level) {
+  var method = {};
+  var methodName = "log." + level;
+
+  method[methodName] = function(msg) {
+    log[level]({userId:this.userId, clientAddress: this.connection.clientAddress}, msg);
+  }
+
+  Meteor.methods(method)
+}.bind(this));
+

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'electronifie:meteor-llog-bunyan',
   summary: "llog logging with bunyan support",
-  version: "0.0.1",
+  version: "0.0.2",
   git: "https://github.com/electronifie/meteor-llog-bunyan.git"
 });
 

--- a/package.js
+++ b/package.js
@@ -13,4 +13,5 @@ Npm.depends({
 Package.onUse(function(api) {
   api.versionsFrom('METEOR@0.9.0');
   api.addFiles('electronifie-llog-bunyan.js', 'server');
+  api.addFiles('electronifie-llog-bunyan.js', 'client');
 });

--- a/package.js
+++ b/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  "llog": "0.0.10",
+  "llog": "0.0.11",
   "bunyan": "1.5.1"
 });
 


### PR DESCRIPTION
By default, register all bunyan log levels as Meteor methods so you can `Meteor.call "log.debug", "some debug message."`.

Also adds `clientAddress` (ipAddress) and `userId` to log messages.
